### PR TITLE
Change sample Docker compose file to work with NuoDB 4.2

### DIFF
--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     image: nuodb/nuodb-ce:latest
     hostname: sm
     environment:
-      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCMD_API_SERVER: nuoadmin1:8888
     depends_on:
       - nuoadmin1
     command: [ "nuodocker", "start", "sm", "--db-name", "hockey", "--server-id", "nuoadmin1", "--dba-user", "dba", "--dba-password", "goalie" ]
@@ -18,7 +18,7 @@ services:
     image: nuodb/nuodb-ce:latest
     hostname: te
     environment:
-      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCMD_API_SERVER: nuoadmin1:8888
     depends_on:
       - nuoadmin1
       - sm


### PR DESCRIPTION
NuoDB 4.2 no longer ships default TLS keys.

Remove the TLS enforcement to enable the compose file to detect whether NuoDB is running with or without LTS.