### PR TITLE
added adhoc filter back.

### DIFF
--- a/conf/provisioning/dashboards/nuodb/adhoc.json
+++ b/conf/provisioning/dashboards/nuodb/adhoc.json
@@ -2072,6 +2072,16 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "datasource": "nuodb",
+        "error": null,
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
       }
     ]
   },


### PR DESCRIPTION
adhoc filter was removed.  not sure if that was on purpose or not.  Added back as it's needed to filter out to database or something else.  It might be best to change from adhoc filter to same as other displays.